### PR TITLE
Add support for XML requests and content

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ alma_rest_api_init.rb in `config/initializers`
 AlmaRestApi.configure do |config|
   config.api_key = "l7xx..."
   config.api_path = "https://api-eu.hosted.exlibrisgroup.com/almaws/v1"
+  config.api_format = :"application/xml"
 end
 ```
 
 OR via environment variables:
 * `ALMA_API_KEY`  
 * `ALMA_API_PATH` (default https://api-na.hosted.exlibrisgroup.com/almaws/v1)
+* `ALMA_APIFORMAT` (default `:json`)
 
 ## Usage
 

--- a/lib/alma_rest_api.rb
+++ b/lib/alma_rest_api.rb
@@ -19,9 +19,13 @@ module AlmaRestApi
       begin
         response = 
          RestClient.get uri(uri),
-            accept: :json, 
+            accept: configuration.api_format,
             authorization: 'apikey ' + configuration.api_key
-        return JSON.parse(response.body)
+        if configuration.api_format == :"application/xml"
+          return Nokogiri::XML.parse(response.body)
+        else
+          return JSON.parse(response.body)
+        end
       rescue => e
         raise AlmaApiError, parse_error(e.response)
       end 
@@ -32,11 +36,15 @@ module AlmaRestApi
       begin
         response =
          RestClient.put uri(uri),
-          data.to_json,
-          accept: :json, 
+          configuration.api_format == :"application/xml" ? data.to_xml : data.to_json,
+          accept: configuration.api_format,
           authorization: 'apikey ' + configuration.api_key,
-          content_type: :json
-        return JSON.parse(response.body)   
+          content_type: configuration.api_format
+        if configuration.api_format == :"application/xml"
+          return Nokogiri::XML.parse(response.body)
+        else
+          return JSON.parse(response.body)
+        end
       rescue => e
         raise AlmaApiError, parse_error(e.response)
       end 
@@ -47,11 +55,15 @@ module AlmaRestApi
       begin
         response =
          RestClient.post uri(uri),
-          data.to_json,
-          accept: :json, 
+          configuration.api_format == :"application/xml" ? data.to_xml : data.to_json,
+          accept: configuration.api_format,
           authorization: 'apikey ' + configuration.api_key,
-          content_type: :json
-        return JSON.parse(response.body)  
+          content_type: configuration.api_format
+        if configuration.api_format == :"application/xml"
+          return Nokogiri::XML.parse(response.body)
+        else
+          return JSON.parse(response.body)
+        end
       rescue => e
         raise AlmaApiError, parse_error(e.response)
       end         
@@ -77,6 +89,7 @@ module AlmaRestApi
 
     def check_config
       raise NoApiKeyError if configuration.api_key.nil? || configuration.api_key.empty?
+      raise InvalidApiFormatError unless [:json, :"application/xml"].include? configuration.api_format
     end
 
     def parse_error(err)
@@ -108,15 +121,23 @@ end
 class Configuration
   attr_accessor :api_key
   attr_accessor :api_path
+  attr_accessor :api_format
 
   def initialize
     @api_key = ENV['ALMA_APIKEY']
     @api_path = ENV['ALMA_APIPATH'] || "https://api-na.hosted.exlibrisgroup.com/almaws/v1"
+    @api_format = ENV['ALMA_APIFORMAT'] || :json
   end
 end
 
 class NoApiKeyError < StandardError
   def initialize(msg="No API key defined")
+    super
+  end
+end
+
+class InvalidApiFormatError < StandardError
+  def initialize(msg="API format must be :json or :\"application/xml\"")
     super
   end
 end


### PR DESCRIPTION
This is an approach to building in XML support (to resolve #1) by:

- Adding an optional `api_format` configuration attribute (the default value remains `:json`)
- Defining an `InvalidApiFormatError` for when the attribute is set to an unsupported value
- Using Nokogiri methods for XML data

Not sure if this is the optimal solution, but it's working for me so far and I hope is a step in the right direction. Glad to make adjustments as needed. This commit doesn't include a change to the gem version.

---

One detail: I found that I had to specify the new format as `:"application/xml"` instead of just `:xml`, because when mime-types (via rest-client) queries its registry for the latter, it defaults to `text/xml`:

```
> puts MIME::Types.type_for('xml')
text/xml
application/xml
nil
```

Requesting `text/xml` returned a 406 Not Acceptable error:

```
RestClient.get "https://api-na.hosted.exlibrisgroup.com/almaws/v1/bibs/991000027889705706/holdings/22240075110005706", "Accept"=>"text/xml", "Accept-Encoding"=>"gzip, deflate", "Authorization"=>"apikey ...", "User-Agent"=>"rest-client/2.0.2 (mingw32 x86_64) ruby/2.4.3p205"
# => 406 NotAcceptable | application/json 137 bytes
```

which then raised the "Unknown error from Alma" message, because `error["web_service_result"]["errorList"]["error"]["errorMessage"]` was blank:

```
{"web_service_result":{"errorsExist":true,"errorList":{"error":{"errorCode":"NOT_ACCEPTABLE","errorMessage":"","trackingId":"unknown"}}}}
```